### PR TITLE
Preserve links during English slug migration

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - ".github/workflows/pages.yml"
       - "config.yaml"
+      - "content-migrations/**"
+      - "scripts/**"
+      - "tests/**"
       - "theme/**"
       - "CNAME"
 
@@ -42,12 +45,21 @@ jobs:
       - name: Set up Python
         run: uv python install 3.11
 
+      - name: Test site migration tooling
+        run: python3 -m unittest -v tests/test_render_slug_redirects.py
+
       - name: Generate site from the site Config
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: >-
           uv run --project "$GITHUB_WORKSPACE/compiler" --frozen
           blog-gen --config "$GITHUB_WORKSPACE/config.yaml"
+
+      - name: Render Blog slug compatibility pages
+        run: >-
+          python3 scripts/render_slug_redirects.py
+          --map content-migrations/blog-slugs-2026-08.json
+          --output output
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/content-migrations/blog-slugs-2026-08.json
+++ b/content-migrations/blog-slugs-2026-08.json
@@ -1,0 +1,121 @@
+{
+  "origin": "https://geoqiao.me",
+  "redirects": [
+    {
+      "from": "/blog/rye-hao-yong-de-pythonbao-guan-li-gong-ju/",
+      "to": "/blog/rye-python-package-manager-guide/"
+    },
+    {
+      "from": "/blog/excel-xue-xi-jing-yan-fen-xiang/",
+      "to": "/blog/practical-excel-learning-tips/"
+    },
+    {
+      "from": "/blog/with-sql-as-english/",
+      "to": "/blog/learn-sql-in-plain-english/"
+    },
+    {
+      "from": "/blog/guan-yu-li-shi/",
+      "to": "/blog/history-as-a-rolling-wheel/"
+    },
+    {
+      "from": "/blog/kong-diao-bo-xue-li-lun-de-ti-chu/",
+      "to": "/blog/air-conditioning-exploitation-theory/"
+    },
+    {
+      "from": "/blog/zong-de-huo-zhao-ba/",
+      "to": "/blog/why-we-still-choose-to-live/"
+    },
+    {
+      "from": "/blog/ji-yu-github-issues-de-ge-ren-blog-da-jian/",
+      "to": "/blog/github-issues-blog-setup-guide/"
+    },
+    {
+      "from": "/blog/shottr-yuan-sheng-qing-qiao-qie-gong-neng-qiang-da-de-mian-fei-tu-gong/",
+      "to": "/blog/shottr-lightweight-macos-screenshot-tool/"
+    },
+    {
+      "from": "/blog/pythonhuan-jing-an-zhuang-anacondawei-li/",
+      "to": "/blog/install-python-with-anaconda/"
+    },
+    {
+      "from": "/blog/zhong-qi-qing-yong-obsidian/",
+      "to": "/blog/use-obsidian-the-simple-way/"
+    },
+    {
+      "from": "/blog/wo-de-di-yi-ge-wan-zheng-de-ji-qi-xue-xi-xiang-mu-titaniczong-jie/",
+      "to": "/blog/my-first-titanic-machine-learning-project/"
+    },
+    {
+      "from": "/blog/zong-you-yi-xie-app-zhi-neng-windows-yong/",
+      "to": "/blog/run-windows-apps-on-mac-with-vmware/"
+    },
+    {
+      "from": "/blog/pythonbian-ji-qi-wo-de-vscodepei-zhi/",
+      "to": "/blog/my-vscode-setup-for-python/"
+    },
+    {
+      "from": "/blog/ji-yu-fastapi-de-crud-lian-xi-rss-ding-yue-guan-li/",
+      "to": "/blog/build-an-rss-manager-with-fastapi/"
+    },
+    {
+      "from": "/blog/shi-yong-python-he-github-pages-da-jian-ge-ren-bo-ke/",
+      "to": "/blog/build-a-python-blog-on-github-pages/"
+    },
+    {
+      "from": "/blog/uv-github-20k-star-de-zhong-ji-python-xiang-mu-guan-li-gong-ju/",
+      "to": "/blog/uv-python-project-management-guide/"
+    },
+    {
+      "from": "/blog/wei-github-pages-ge-ren-bo-ke-tian-jia-yaml-pei-zhi-gong-neng-ji-yu/",
+      "to": "/blog/add-yaml-config-to-github-pages-blog/"
+    },
+    {
+      "from": "/blog/bu-yao-jiu-jie-liao-zai-pandaszhong-shu-ju-shai-xuan-jiu-yong-ta/",
+      "to": "/blog/filter-pandas-dataframes-with-loc/"
+    },
+    {
+      "from": "/blog/ru-he-dui-lian-xu-xing-shu-ju-jin-xing-fen-xiang-python/",
+      "to": "/blog/optimal-binning-for-continuous-data-in-python/"
+    },
+    {
+      "from": "/blog/python-huan-jing-pei-zhi-cong-ling-kai-shi-uv-pdm-he-vscode-de-zui-jia/",
+      "to": "/blog/python-setup-with-uv-pdm-and-vscode/"
+    },
+    {
+      "from": "/blog/pei-zhi-vscode-de-mian-fei-ai-bian-cheng-zhu-shou-ollama-groqhe-kuo/",
+      "to": "/blog/free-vscode-ai-with-ollama-groq-and-continue/"
+    },
+    {
+      "from": "/blog/2024nian-zhong-zong-jie-kong-zhi-yu-qi-jian-chi-xia-qu/",
+      "to": "/blog/2024-review-manage-expectations-and-keep-going/"
+    },
+    {
+      "from": "/blog/wo-xi-huan-dong-tian-de-xia-wu-zou-lu-qu-cheng-du-de-cha-guan-he-cha/",
+      "to": "/blog/winter-walks-to-chengdu-teahouses/"
+    },
+    {
+      "from": "/blog/2025nian-zhong-zong-jie-guan-zhu-zi-ji/",
+      "to": "/blog/2025-review-focus-on-yourself/"
+    },
+    {
+      "from": "/blog/vibe-coding-shi-zhan-hou-gan-github-blog-with-trae/",
+      "to": "/blog/vibe-coding-github-blog-with-trae/"
+    },
+    {
+      "from": "/blog/bu-dong-git-bu-hui-qian-duan-yi-ge-wen-ke-sheng-de-github-blog/",
+      "to": "/blog/build-a-github-blog-without-git-or-frontend/"
+    },
+    {
+      "from": "/blog/cong-superpowers-xue-xi-gao-zhi-liang-ai-xie-zuo-yi-fen-gei-ce-lue-fen/",
+      "to": "/blog/superpowers-claude-code-guide-for-strategy-analysts/"
+    },
+    {
+      "from": "/blog/cong-obsidian-dao-bo-ke-wo-ru-he-yong-yi-tiao-ming-ling-ba-bi-ji-bian/",
+      "to": "/blog/publish-obsidian-notes-with-one-command/"
+    },
+    {
+      "from": "/blog/what-s-on-my-pi-agent-ba-90-de-codex-desktop-zhuang-jin-zhong-duan/",
+      "to": "/blog/terminal-codex-workflow-with-pi-and-herdr/"
+    }
+  ]
+}

--- a/scripts/render_slug_redirects.py
+++ b/scripts/render_slug_redirects.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Render site-owned compatibility pages for one-time Blog slug migrations."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import re
+import sys
+from pathlib import Path
+from urllib.parse import urlsplit
+
+_BLOG_ROUTE = re.compile(r"^/blog/([a-z0-9]+(?:-[a-z0-9]+)*)/$")
+
+
+def _origin(value: object) -> str:
+    if not isinstance(value, str):
+        raise ValueError("origin must be a string")
+    parsed = urlsplit(value)
+    if (
+        parsed.scheme != "https"
+        or not parsed.netloc
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.path not in {"", "/"}
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError("origin must be an HTTPS origin without a path")
+    return f"https://{parsed.netloc}"
+
+
+def _output_path(output: Path, route: object) -> Path:
+    if not isinstance(route, str):
+        raise ValueError("redirect routes must be strings")
+    match = _BLOG_ROUTE.fullmatch(route)
+    if match is None:
+        raise ValueError(f"invalid Blog redirect route: {route!r}")
+    return output / "blog" / match.group(1) / "index.html"
+
+
+def _redirect_html(target_url: str) -> str:
+    escaped = html.escape(target_url, quote=True)
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Page moved</title>
+  <link rel="canonical" href="{escaped}">
+  <meta http-equiv="refresh" content="0; url={escaped}">
+</head>
+<body>
+  <p>This page moved to <a href="{escaped}">{escaped}</a>.</p>
+</body>
+</html>
+"""
+
+
+def render_redirects(mapping_path: Path, output: Path) -> tuple[int, int]:
+    data = json.loads(mapping_path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("redirect map must be a JSON object")
+    origin = _origin(data.get("origin"))
+    redirects = data.get("redirects")
+    if not isinstance(redirects, list):
+        raise ValueError("redirects must be a list")
+    if not output.is_dir():
+        raise ValueError(f"output directory does not exist: {output}")
+
+    plans: list[tuple[Path, str] | None] = []
+    seen_sources: set[str] = set()
+    seen_targets: set[str] = set()
+    for entry in redirects:
+        if not isinstance(entry, dict) or set(entry) != {"from", "to"}:
+            raise ValueError("each redirect requires exactly 'from' and 'to'")
+        source_route = entry["from"]
+        target_route = entry["to"]
+        if not isinstance(source_route, str) or not isinstance(target_route, str):
+            raise ValueError("redirect routes must be strings")
+        if source_route == target_route:
+            raise ValueError(f"redirect source equals target: {source_route!r}")
+        if source_route in seen_sources:
+            raise ValueError(f"duplicate redirect source: {source_route!r}")
+        if target_route in seen_targets:
+            raise ValueError(f"duplicate redirect target: {target_route!r}")
+        seen_sources.add(source_route)
+        seen_targets.add(target_route)
+
+        source = _output_path(output, source_route)
+        target = _output_path(output, target_route)
+        if target.exists():
+            if source.exists():
+                raise ValueError(
+                    f"both source and target canonical pages exist: {source_route!r}"
+                )
+            plans.append((source, f"{origin}{target_route}"))
+        elif source.exists():
+            plans.append(None)
+        else:
+            raise ValueError(
+                f"neither source nor target exists: {source_route!r} -> {target_route!r}"
+            )
+
+    created = 0
+    skipped = 0
+    for plan in plans:
+        if plan is None:
+            skipped += 1
+            continue
+        source, target_url = plan
+        source.parent.mkdir(parents=True, exist_ok=False)
+        source.write_text(_redirect_html(target_url), encoding="utf-8")
+        created += 1
+    return created, skipped
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--map", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    try:
+        created, skipped = render_redirects(args.map, args.output)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"redirect rendering failed: {exc}", file=sys.stderr)
+        return 1
+    print(f"slug redirects: created={created} skipped={skipped}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_render_slug_redirects.py
+++ b/tests/test_render_slug_redirects.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPOSITORY_ROOT / "scripts" / "render_slug_redirects.py"
+
+
+class RenderSlugRedirectsTests(unittest.TestCase):
+    def run_script(
+        self, output: Path, redirects: list[dict[str, str]]
+    ) -> subprocess.CompletedProcess[str]:
+        mapping = output.parent / "redirects.json"
+        mapping.write_text(
+            json.dumps(
+                {
+                    "origin": "https://geoqiao.me",
+                    "redirects": redirects,
+                }
+            ),
+            encoding="utf-8",
+        )
+        return subprocess.run(  # noqa: S603 - fixed test command
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--map",
+                str(mapping),
+                "--output",
+                str(output),
+            ],
+            cwd=REPOSITORY_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_cli_renders_compatible_page_for_migrated_slug(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            output = root / "output"
+            target = output / "blog" / "new-english-slug" / "index.html"
+            target.parent.mkdir(parents=True)
+            target.write_text("new canonical page", encoding="utf-8")
+
+            result = self.run_script(
+                output,
+                [{"from": "/blog/old-pinyin-slug/", "to": "/blog/new-english-slug/"}],
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            redirect = output / "blog" / "old-pinyin-slug" / "index.html"
+            html = redirect.read_text(encoding="utf-8")
+            self.assertIn(
+                '<link rel="canonical" href="https://geoqiao.me/blog/new-english-slug/">',
+                html,
+            )
+            self.assertIn(
+                'content="0; url=https://geoqiao.me/blog/new-english-slug/"', html
+            )
+            self.assertIn('href="https://geoqiao.me/blog/new-english-slug/"', html)
+            self.assertIn("created=1 skipped=0", result.stdout)
+
+    def test_cli_leaves_current_canonical_page_untouched_before_cutover(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            output = root / "output"
+            source = output / "blog" / "old-pinyin-slug" / "index.html"
+            source.parent.mkdir(parents=True)
+            source.write_text("current canonical page", encoding="utf-8")
+
+            result = self.run_script(
+                output,
+                [{"from": "/blog/old-pinyin-slug/", "to": "/blog/new-english-slug/"}],
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(
+                source.read_text(encoding="utf-8"), "current canonical page"
+            )
+            self.assertFalse(
+                (output / "blog" / "new-english-slug" / "index.html").exists()
+            )
+            self.assertIn("created=0 skipped=1", result.stdout)
+
+    def test_cli_fails_when_neither_side_exists(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            output = root / "output"
+            output.mkdir()
+
+            result = self.run_script(
+                output,
+                [{"from": "/blog/old-pinyin-slug/", "to": "/blog/new-english-slug/"}],
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("neither source nor target exists", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add the approved 29-entry Blog slug migration map
- render static old-to-new compatibility pages after site generation
- validate the migration tooling in the Pages workflow

## Verification
- `python3 -m unittest -v tests/test_render_slug_redirects.py`
- real-data branch build succeeded
- pre-cutover build reported `created=0 skipped=29`

This PR installs the compatibility layer before the authoritative GitHub Issue slugs are changed.