### PR TITLE
fix: update search identity and favicon

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: geoqiao/escaping
-          ref: 92533f3405fc15f24a72ca344ee8d1c67bb41b24
+          ref: 3271141e5a19953648fa48fd01d764ce52b32e93
           path: compiler
 
       - name: Install uv

--- a/config.yaml
+++ b/config.yaml
@@ -11,9 +11,9 @@ github:
 # 拥有标题、作者显示名、规范 HTTPS 源、描述、语言和导航
 # ============================================
 site:
-  title: geoqiao's Blog
+  title: Geo Qiao
   url: https://geoqiao.me/
-  author: geoqiao
+  author: Geo Qiao
   description: ""
   language: zh-CN
   navigation:


### PR DESCRIPTION
## What changed

- set the site title and author display name to `Geo Qiao`
- pin the Pages workflow to `escaping@3271141e5a19953648fa48fd01d764ce52b32e93`

## Why

The previous favicon was served as `image/png` but contained JPEG bytes, so search engines could not reliably adopt it. The homepage also advertised `geoqiao's Blog` in its title, Open Graph metadata, and `WebSite` structured data instead of the preferred site name.

## Impact

The generated homepage now uses `Geo Qiao` consistently for visible identity, title metadata, Open Graph, and `WebSite.name`. The pinned generator ships a real 96 x 96 PNG at the existing stable favicon URL. Google Search remains automated and may need a recrawl before its result changes.

## Verification

- `uv run pytest -q` in `escaping`: 194 passed
- Ruff lint, format, `ty check`, and `git diff --check`: passed
- real site build using the production config and GitHub Issues: 106 artifacts
- slug migration tests: 3 passed
- slug compatibility render: 29 pages created
- generated favicon: valid 96 x 96 PNG matching the pinned generator asset
