### PR TITLE
feat: add escaping and JoJo Codex Pet to Projects

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -93,6 +93,37 @@ comments:
   theme_mode: auto
 
 # ============================================
+# Projects（站点维护的公开项目目录）
+# GitHub metadata 会在构建时刷新；fallback 只保留稳定字段
+# ============================================
+projects:
+  - slug: escaping
+    title: escaping
+    repository: geoqiao/escaping
+    summary: 以 GitHub Issues 为内容源、带严格校验与原子发布的个人静态站点生成器。
+    featured: true
+    order: 1
+    fallback_metadata:
+      language: Python
+      topics:
+        - github-issues
+        - static-site-generator
+        - github-pages
+
+  - slug: jojo-codex-pet
+    title: JoJo Codex Pet
+    repository: geoqiao/jojo-codex-pet
+    summary: 非官方、非商业的 JoJo 主题 Codex Pet V2 图鉴、安装包与双语画廊。
+    featured: true
+    order: 2
+    fallback_metadata:
+      language: Astro
+      topics:
+        - codex-pet
+        - fan-project
+        - pixel-art
+
+# ============================================
 # 安全配置
 # token_env 动态决定 Token 环境变量名，不硬编码
 # ============================================


### PR DESCRIPTION
## What changed

- added `escaping` as the first featured project
- added `JoJo Codex Pet` as the second featured project
- provided stable language/topic fallback metadata while retaining live GitHub enrichment for stars, forks, language, and topics
- identified JoJo Codex Pet as an unofficial, non-commercial fan project in its public summary

## Why

The Projects route existed but had no configured projects, so the public page rendered an empty state.

## Impact

Merging this PR triggers the Pages workflow and publishes two project cards at `/projects/`.

## Validation

- generated the full site from the real Config and GitHub Issues using the pinned-compatible local compiler
- verified exactly two rendered project rows, their order, summaries, and GitHub links
- `python3 -m unittest -v tests/test_render_slug_redirects.py` — 3 passed
- rendered 29 compatibility redirects successfully
- `git diff --check`
