### PR TITLE
chore: publish ranked homepage projects

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: geoqiao/escaping
-          ref: 3271141e5a19953648fa48fd01d764ce52b32e93
+          ref: 842e21125715275596f51aad1629d9f0acd0391c
           path: compiler
 
       - name: Install uv


### PR DESCRIPTION
## What changed

- update the pinned `geoqiao/escaping` compiler from `3271141e5a19953648fa48fd01d764ce52b32e93` to `842e21125715275596f51aad1629d9f0acd0391c`

## Why

The new compiler replaces the hard-coded homepage project card with up to five configured projects ranked by live GitHub stars. It also retains the previously deployed valid favicon assets.

## Impact

Merging this PR triggers the Pages workflow and publishes the new homepage Projects list. The Projects catalog itself remains unchanged.

## Validation

- generated the complete real site using the exact pinned merge SHA and current production Config
- verified the homepage renders `escaping` and `JoJo Codex Pet` in descending star order with metadata and `/projects/` link
- `python3 -m unittest -v tests/test_render_slug_redirects.py` — 3 passed
- rendered 29 compatibility redirects successfully
- `git diff --check`
