### PR TITLE
Pin escaping typography release

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: geoqiao/escaping
-          ref: 5de375ac9137e19ca84a256c4255c0e3521ba359
+          ref: 0a62f3d9c55bd82b611b3899a6aa4ca29fef7595
           path: compiler
 
       - name: Install uv


### PR DESCRIPTION
## What changed\n- pin the production site workflow to escaping 0a62f3d9c55bd82b611b3899a6aa4ca29fef7595\n\n## Why\nDeploy typography Scheme B for the built-in geoqiao.me Theme.\n\n## Validation\n- python3 -m unittest -v tests/test_render_slug_redirects.py (3 passed)\n- branch workflow performs the pinned compiler consumer build before merge