### PR TITLE
Pin escaping navigation polish

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: geoqiao/escaping
-          ref: 0a62f3d9c55bd82b611b3899a6aa4ca29fef7595
+          ref: af15bb0ed0bcf6fffa4b71fa18c6b2e218d5bf15
           path: compiler
 
       - name: Install uv


### PR DESCRIPTION
## What changed

- pin the production Pages workflow to `geoqiao/escaping@af15bb0ed0bcf6fffa4b71fa18c6b2e218d5bf15`

## User impact

- native and accessible mobile menu button
- centered mobile navigation and theme controls
- improved touch targets, current-page state, and theme-color synchronization
- browser-native lazy loading and async decoding for content images
- Markdown table behavior remains unchanged

## Validation

- generator suite: 198 passed; Ruff, formatting, ty, and diff checks passed
- site migration suite: 3 passed
- full site generated from the production config using the exact pinned GitHub SHA
- generated artifacts checked for menu semantics, current navigation state, cache key, and image loading attributes

## Rollback

Restore the previous compiler pin: `0a62f3d9c55bd82b611b3899a6aa4ca29fef7595`.
