### PR TITLE
Pin escaping typography release

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: geoqiao/escaping
-          ref: af15bb0ed0bcf6fffa4b71fa18c6b2e218d5bf15
+          ref: e5beb636853f821f93490cfa5112bafff693d63d
           path: compiler
 
       - name: Install uv


### PR DESCRIPTION
## Summary
- pin the production site workflow to escaping `e5beb636853f821f93490cfa5112bafff693d63d`
- deploy the revised Chinese reading typography while preserving the LXGW WenKai homepage epigraph

## Consumer verification
- generated the site from the production `config.yaml` with the pinned compiler
- rendered 29 slug compatibility pages
- verified Home, Blog, Ideas, About, Projects, Tags, Atom, sitemap, and robots artifacts
- verified the generated pages reference Source Serif 4, Noto Serif SC, and LXGW WenKai
- `python3 -m unittest -v tests/test_render_slug_redirects.py` (3 passed)