### PR TITLE
Pin reviewed escaping generator and migrate site identity

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: geoqiao/escaping
-          ref: 0ab8137cdc525e5e58113c1471da98a940135ee8
+          ref: e3cb63855cad5d964f1a0e428d4956ed0ad44697
           path: compiler
 
       - name: Install uv

--- a/config.yaml
+++ b/config.yaml
@@ -16,6 +16,9 @@ site:
   author: Geo Qiao
   description: ""
   language: zh-CN
+  thesis:
+    - 演悲欢离合，当代岂无前代事？
+    - 观抑扬褒贬，座中常有剧中人。
   navigation:
     items:
       - name: Blog
@@ -33,10 +36,11 @@ site:
 
 # ============================================
 # 站点档案（Site Profile）
-# 仅包含头像、简介和链接；详细 About 叙述属于 About Issue Content
+# 仅包含头像、简短标签、简介和链接；详细 About 叙述属于 About Issue Content
 # ============================================
 profile:
   avatar: https://github.com/geoqiao.png
+  tagline: 贷后策略分析师 / tool tinkerer
   bio: |
     你好，我是 geoqiao。
     一名金融行业的贷后策略分析师，喜欢折腾工具，也享受用代码解决重复性工作。


### PR DESCRIPTION
## Summary

- pin `geoqiao/escaping` at full SHA `e3cb63855cad5d964f1a0e428d4956ed0ad44697`
- migrate the Home Site Thesis from Theme literals into `site.thesis`
- migrate the profile role into `profile.tagline`

## Validation

- site migration tooling: 3 tests passed
- strict Config load against the exact pinned generator SHA passed
- `git diff --check` passed

## Deployment

Merging to `main` triggers the guarded Pages build/deploy workflow.