### PR TITLE
Pin hardened escaping release

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: geoqiao/escaping
-          ref: e3cb63855cad5d964f1a0e428d4956ed0ad44697
+          ref: b8862451fa2b90be1377ab52deecf73dde4617b5
           path: compiler
 
       - name: Install uv

--- a/config.yaml
+++ b/config.yaml
@@ -104,7 +104,7 @@ projects:
   - slug: escaping
     title: escaping
     repository: geoqiao/escaping
-    summary: 以 GitHub Issues 为内容源、带严格校验与原子发布的个人静态站点生成器。
+    summary: 以 GitHub Issues 为内容源、带严格校验与分阶段发布的个人静态站点生成器。
     featured: true
     order: 1
     fallback_metadata:


### PR DESCRIPTION
## Summary

- pin the site workflow to escaping `b8862451fa2b90be1377ab52deecf73dde4617b5` (#14)
- update the public escaping project summary from the obsolete atomic-publication wording to staged publication

## Compatibility verification

- site migration tests: 3 passed
- generated the complete site against the pinned generator using the real site config
- verified Home, Atom, sitemap, robots, thesis/tagline, and mobile-navigation scrim
- generated 109 files successfully

The generator PR passed both Python 3.11 and 3.14 CI legs, including its real Chromium navigation regression.
