### PR TITLE
chore: deploy geoqiao theme redesign

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: geoqiao/escaping
-          ref: b8862451fa2b90be1377ab52deecf73dde4617b5
+          ref: 5eb34f6ef8212586374865d1e65ff7bffd608963
           path: compiler
 
       - name: Install uv


### PR DESCRIPTION
## Summary
- pin the production Pages workflow to `geoqiao/escaping@5eb34f6ef8212586374865d1e65ff7bffd608963`
- deploy the reviewed `geoqiao.me` personal writing theme redesign from geoqiao/escaping#15

## Consumer verification
- generated the site from the real production `config.yaml` with the exact pinned compiler SHA
- site migration tests: 3 passed
- rendered 29 Blog slug compatibility redirects
- verified Home, Blog, Ideas, About, Projects, Tags, Theme assets, comments binding, TOC, canonical/OG/Twitter metadata, Atom, sitemap, and robots artifacts
