### PR TITLE
fix: deploy mobile and About refinements

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: geoqiao/escaping
-          ref: 5eb34f6ef8212586374865d1e65ff7bffd608963
+          ref: 8d428b77d941afb3ac2749258e07434457e4f3f0
           path: compiler
 
       - name: Install uv

--- a/config.yaml
+++ b/config.yaml
@@ -39,7 +39,7 @@ site:
 # 仅包含头像、简短标签、简介和链接；详细 About 叙述属于 About Issue Content
 # ============================================
 profile:
-  avatar: https://github.com/geoqiao.png
+  avatar: /templates/geoqiao.me/static/images/author-mark.png
   tagline: 贷后策略分析师 / tool tinkerer
   bio: |
     你好，我是 geoqiao。


### PR DESCRIPTION
## Summary
- pin production to `geoqiao/escaping@8d428b77d941afb3ac2749258e07434457e4f3f0`
- use the new transparent GQ author mark as the configured About avatar
- deploy the About copy de-duplication, mobile Blog title layout, and centered expanded navigation

## Consumer verification
- generated from the real production Config with the exact pinned compiler SHA
- site migration tests: 3 passed
- rendered 29 compatibility redirects
- verified About copy appears once, the old GitHub avatar is absent, the new author mark is present, and the updated mobile stylesheet is referenced
