### PR TITLE
fix: deploy About reading scale

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: geoqiao/escaping
-          ref: 8d428b77d941afb3ac2749258e07434457e4f3f0
+          ref: cfec81fdcee6f321fc433f2cb4342d3243ced6f1
           path: compiler
 
       - name: Install uv

--- a/config.yaml
+++ b/config.yaml
@@ -41,10 +41,6 @@ site:
 profile:
   avatar: /templates/geoqiao.me/static/images/author-mark.png
   tagline: 贷后策略分析师 / tool tinkerer
-  bio: |
-    你好，我是 geoqiao。
-    一名金融行业的贷后策略分析师，喜欢折腾工具，也享受用代码解决重复性工作。
-    工作之余，我喜欢记录生活中的碎片。
   links:
     - name: GitHub
       url: https://github.com/geoqiao


### PR DESCRIPTION
## Summary
- pin production to `geoqiao/escaping@cfec81fdcee6f321fc433f2cb4342d3243ced6f1`
- deploy the 720px About identity/reading scale, smaller title and author mark, and scoped section-heading scale
- remove duplicated `profile.bio` from Config so the About Issue remains the only authoritative source for the narrative

## Consumer verification
- generated with the real production Config and exact pinned compiler SHA
- site migration tests: 3 passed
- rendered 29 compatibility redirects
- verified the v3 stylesheet, configured author mark, 42–80px About title scale, 96–160px mark scale, and 22–26px About section title scale
