### PR TITLE
deploy: pin escaping 71ef7f6

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: geoqiao/escaping
-          ref: cfec81fdcee6f321fc433f2cb4342d3243ced6f1
+          ref: 71ef7f68029a35e64ab0ba62a6595e770588ad99
           path: compiler
           persist-credentials: false
 


### PR DESCRIPTION
## Summary
Update the production generator pin from cfec81fdcee6f321fc433f2cb4342d3243ced6f1 to the merged escaping PR #18 SHA:

71ef7f68029a35e64ab0ba62a6595e770588ad99

## Verified consumer
- production Config validates against the new generator
- 11 redirect/containment tests pass
- full site generation succeeds
- 29 slug redirects created
- final artifact validation succeeds with 222 entries
- Mermaid runtime is local and present under the selected Theme output
- no jsdelivr, Google Fonts, or unpkg runtime references

This PR intentionally changes only the immutable generator ref.