### PR TITLE
chore: pin escaping compiler to 7e50120

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: geoqiao/escaping
-          ref: 71ef7f68029a35e64ab0ba62a6595e770588ad99
+          ref: 7e50120da7dd7ed17b7b266fb962a2fe9b5ef8a2
           path: compiler
           persist-credentials: false
 


### PR DESCRIPTION
## Summary

Pin the production Pages workflow's `geoqiao/escaping` checkout to the reviewed, merged compiler commit `7e50120da7dd7ed17b7b266fb962a2fe9b5ef8a2`.

**Scope:** exactly one production-facing change: replace only that workflow `ref:` value. No action pins, concurrency, config, CNAME, migrations, scripts, tests, theme, Pages settings, or other workflow behavior changed.

## Generator provenance

- Generator PR #19: https://github.com/geoqiao/escaping/pull/19
- PR #19 is merged to `main` with merge commit `7e50120da7dd7ed17b7b266fb962a2fe9b5ef8a2`.
- The reviewed source passed local/full CI and independent Opus review.
- GitHub PR checks passed on Python 3.11 and 3.14.

## Validation

- YAML parse: passed.
- Site migration/unit tests: `python3 -m unittest -v tests/test_render_slug_redirects.py` — 3 passed.
- Exact-SHA site build: passed with the compiler checked out at `7e50120da7dd7ed17b7b266fb962a2fe9b5ef8a2`, using `config.yaml`, existing GitHub CLI authentication, `uv run --project ... --frozen escpe`, and the workflow's slug-redirect step.
- Representative artifacts verified: Home, Blog, Ideas, About, Projects, Tags, `atom.xml`, `sitemap.xml`, and `robots.txt`.
- `git diff --check`: passed.

## Rollback

Restore the previous full compiler SHA in the same `ref:` line:
`b8862451fa2b90be1377ab52deecf73dde4617b5`.